### PR TITLE
Add ISO feed type

### DIFF
--- a/Contents/Code/game.py
+++ b/Contents/Code/game.py
@@ -41,6 +41,7 @@ class Feed(object):
                     'FRENCH': "%s (French)" % (tv_station),
                     'NATIONAL': "%s (National)" % (tv_station),
                     'COMPOSITE': "3-Way Camera (Composite)",
+                    'ISO': 'Multi-Angle',
                     'NONVIEWABLE': "Non-viewable"
                 }[feed_type]
             return Feed(tv_station, item["mediaPlaybackId"], getTitle(item["mediaFeedType"]))


### PR DESCRIPTION
Today's schedule (3/28/17) has several feeds of type ISO, which causes loading today's games to fail. Based on the feedName field these appear to be "multi-angle" streams. I'm not sure what the difference between this and the composite streams are, and there may be a better name for these streams, but this does fix the error.