### PR TITLE
Normal recap page should no longer error

### DIFF
--- a/Contents/Code/game.py
+++ b/Contents/Code/game.py
@@ -122,7 +122,7 @@ class Game:
         self.game_id = gameId
 
     def getRecaps(self, type):
-        if type == 'recap':
+        if type == 'recaps':
             return self.recaps
         return self.extended_highlights
 


### PR DESCRIPTION
Looks like line 187 in \_\_init\_\_.py is passing the string "recaps":
`oc.add(getRecapVCO(date, "recaps", r))`

but line 125 in game.py was expecting "recap".
`if type == 'recap':`

Changed game.py so that it is now using 'recaps'. Now the normal (non-extended) recap page is displaying (it was erroring out for me before).