### PR TITLE
Fixing issue where NHL games on or after 1-28-18 were not showing up

### DIFF
--- a/Contents/Code/game.py
+++ b/Contents/Code/game.py
@@ -201,13 +201,16 @@ class Game:
             if sport == "nhl":
                 game.title = "%s @ %s (%s)" % (away["teamName"], home["teamName"], game.time_remaining)
                 summary_format = "%s (%s) from %s (%s) hosts %s (%s) from %s (%s) at %s"
-                game.summary = summary_format % (
-                    game.home_full_name, record(g["teams"]["home"]["leagueRecord"]),
-                    home["division"]["name"], home["conference"]["name"],
-                    game.away_full_name, record(g["teams"]["away"]["leagueRecord"]),
-                    away["division"]["name"], away["conference"]["name"],
-                    g["venue"]["name"]
-                )
+				try:
+					game.summary = summary_format % (
+						game.home_full_name, record(g["teams"]["home"]["leagueRecord"]),
+						home["division"]["name"], home["conference"]["name"],
+						game.away_full_name, record(g["teams"]["away"]["leagueRecord"]),
+						away["division"]["name"], away["conference"]["name"],
+						g["venue"]["name"]
+					)
+				except:
+					game.summary = "Unknown"
             else:
                 game.title = "%s @ %s (%s)" % (away["teamName"], home["teamName"], datetime.strftime(game.time-timedelta(hours=4), "%I:%M%p").lstrip("0"))
                 summary_format = "%s (%s) from %s hosts %s (%s) from %s at %s"

--- a/Contents/Code/game.py
+++ b/Contents/Code/game.py
@@ -209,7 +209,7 @@ class Game:
 						away["division"]["name"], away["conference"]["name"],
 						g["venue"]["name"]
 					)
-				except:
+				except KeyError:
 					game.summary = "Unknown"
             else:
                 game.title = "%s @ %s (%s)" % (away["teamName"], home["teamName"], datetime.strftime(game.time-timedelta(hours=4), "%I:%M%p").lstrip("0"))


### PR DESCRIPTION
This will set the game summary to "Unknown" if any KeyError is encountered when parsing from the API. Since the all star game on 1-28-18, no games are showing up because the 'division' and 'conference' keys don't exist.