### PR TITLE
Workaround SSL error for MLB by using HTTP

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -198,7 +198,7 @@ def getStreamVCO(date, game, feed):
 		else:
 		   url = "http://powersports.ml/mlb/m3u8/%s/%s" % (date, feed.mediaId)
 		try:
-			real_url = HTTP.Request(url + cdn).content
+			real_url = HTTP.Request(url + cdn).content.replace('https', 'http')
 		except:
 			return []
 


### PR DESCRIPTION
This should fix the crash from #46.  I also had to add `playback.svcs.mlb.com` to my hosts file. I don't know why the https url is causing a crash—the url seems to work in a web browser—but the http link works fine, so I use that instead.