### PR TITLE
Fix old dates and upgrade MLB date and game list

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -311,7 +311,11 @@ def Feeds(date, game_id, sport):
 	oc = ObjectContainer(title2="Feeds for %s" % g.title, no_cache=True)
 
 	for f in filter(lambda f: f.viewable, game.feeds):
-		oc.add(getStreamVCO(date, game, f))
+		try:
+			oc.add(getStreamVCO(date, game, f))
+		except:
+			oc.add(DirectoryObject(title = "Game feed expired.", summary = "Full game feed expired.", thumb=R(THUMB_NHL)))
+			break
 
 	for r in game.recaps:
 		if r.videos == None:
@@ -343,7 +347,7 @@ def StreamMetadata(date, gameid, mediaId, sport, **kwargs):
 	oc.add(getStreamVCO(date, game, feed))
 	return oc
 
-def RecapMetadata(type, date, recapid, sport, includeBandwidths=None):
+def RecapMetadata(type, date, recapid, sport, includeBandwidths=None, **kwargs):
 	game_cache = GetCache(date, sport)
 	recap = None
 	for g in game_cache:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -30,7 +30,7 @@ def Start():
 
 ####################################################################################################
 @handler('/video/lazyman', NAME, art=ICON, thumb=ICON)
-def MainMenu():
+def MainMenu(**kwargs):
 	oc = ObjectContainer()
 	oc.add(DirectoryObject(
 		key=Callback(SelectDate, sport="nhl"),
@@ -49,7 +49,7 @@ def MainMenu():
 
 ####################################################################################################
 @route('/video/lazyman/selectdate')
-def SelectDate(sport):
+def SelectDate(sport, **kwargs):
 
 	oc = ObjectContainer(title2="Select Date")
 	date = datetime.date.today()
@@ -96,7 +96,7 @@ def SelectDate(sport):
 
 ####################################################################################################
 @route('/video/lazyman/date')
-def Date(date, sport):
+def Date(date, sport, **kwargs):
 
 	oc = ObjectContainer(title2="Games on %s" % (date), no_cache=True)
 	game_cache = GetCache(date, sport, True)
@@ -296,7 +296,7 @@ def getStreamVCO(date, game, feed):
 	)
 
 @route('/video/lazyman/feeds')
-def Feeds(date, game_id, sport):
+def Feeds(date, game_id, sport, **kwargs):
 	game = None
 	game_cache = GetCache(date, sport)
 	for g in game_cache:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import datetime
 import random
 import re
@@ -13,12 +14,11 @@ THUMB_NHL = 'nhl_logo.png'
 THUMB_MLB = 'mlb_logo.jpg'
 ICON = 'LM.png'
 
-DAYS_TO_SHOW = 10
-MINIMUM_GAMEDAYS_TO_SHOW = 15
+MINIMUM_GAMEDAYS_TO_SHOW = 10
 PAGE_LIMIT = 100
 NAME = 'Lazyman'
 
-GAME_CACHE = {}
+GAME_CACHE = {'mlb': {},'nhl': {}}
 STREAM_CACHE = {}
 
 ####################################################################################################
@@ -54,46 +54,43 @@ def SelectDate(sport):
 
 	oc = ObjectContainer(title2="Select Date")
 	date = datetime.date.today()
+	if sport == "nhl":
+		thumb = R(THUMB_NHL)
+	else:
+		thumb = R(THUMB_MLB)
 
-	if sport == "mlb":
-		time_delta = datetime.timedelta(days=1)
-		for i in range(DAYS_TO_SHOW):
-	 		oc.add(DirectoryObject(
-	 			key=Callback(Date, date=date, sport=sport),
-				title=date.strftime("%d %B %Y")),
-	 		)
-			date = date - time_delta
-		return oc
-
-	if date.strftime("%Y-%m-%d") not in GAME_CACHE:
-		time_delta = datetime.timedelta(days=25)
-
-		while len(GAME_CACHE) < MINIMUM_GAMEDAYS_TO_SHOW:
+	if date.strftime("%Y-%m-%d") not in GAME_CACHE[sport]:
+		while len(GAME_CACHE[sport]) < MINIMUM_GAMEDAYS_TO_SHOW:
 			# Look 'time_delta' days back for games that have occurred
-			scheduleUrl = GAME_SCHEDULE_URL_NHL % (date - time_delta, date)
+			if sport == "nhl":
+				time_delta = datetime.timedelta(days=25)
+				scheduleUrl = GAME_SCHEDULE_URL_NHL % (date - time_delta, date)
+			else:
+				time_delta = datetime.timedelta(days=10)
+				scheduleUrl = GAME_SCHEDULE_URL_MLB % (date - time_delta, date)
 			schedule = JSON.ObjectFromURL(scheduleUrl, max_size=9000000)
 
 			# Add any dates that had games occur to a list of dates for later use
 			if schedule["totalItems"] > 0 or len(schedule["dates"]) != 0:
 				for day in schedule['dates']:
-					GAME_CACHE[day['date']] = Game.fromSchedule(schedule, day['date'])
+					GAME_CACHE[sport][day['date']] = Game.fromSchedule(schedule, day['date'])
 
 			# Change the date by 'time_delta' to contine looking for more games
 			date = date - time_delta
 
-	for game_date in reversed(sorted(GAME_CACHE)):
+	for game_date in reversed(sorted(GAME_CACHE[sport])):
 		splitDate = game_date.split('-')
 		tempDate = datetime.date(int(splitDate[0]), int(splitDate[1]), int(splitDate[2]))
-		title = "%s - %s games" % (tempDate.strftime("%A %d %B %Y"), len(GAME_CACHE[game_date]))
-		for game in GAME_CACHE[game_date]:
+		title = "%s - %s games" % (tempDate.strftime("%A %d %B %Y"), len(GAME_CACHE[sport][game_date]))
+		for game in GAME_CACHE[sport][game_date]:
 			if game.state == "In Progress":
 				title = u"\U0001F3A5 " + title
 				break
 		oc.add(DirectoryObject(
 			key=Callback(Date, date=game_date, sport=sport),
 			title=title,
-			summary=u' \u22c5 '.join(map(lambda x: "%s @ %s" % (x.away_abbr, x.home_abbr), GAME_CACHE[game_date])),
-			thumb=R(THUMB_NHL)
+			summary=u' \u22c5 '.join(map(lambda x: "%s @ %s" % (x.away_abbr, x.home_abbr), GAME_CACHE[sport][game_date])),
+			thumb=thumb
 		))
 
 	return oc 
@@ -123,14 +120,14 @@ def Date(date, sport):
 	return oc
 
 def GetCache(date, sport, refresh=False):
-	if refresh or date not in GAME_CACHE:
+	if refresh or date not in GAME_CACHE[sport]:
 		if sport == "mlb":
 			scheduleUrl = GAME_SCHEDULE_URL_MLB % (date, date)
 		else:
 			scheduleUrl = GAME_SCHEDULE_URL_NHL % (date, date)
 		schedule = JSON.ObjectFromURL(scheduleUrl)
-		GAME_CACHE[date] = Game.fromSchedule(schedule, date)
-	return GAME_CACHE[date]  
+		GAME_CACHE[sport][date] = Game.fromSchedule(schedule, date)
+	return GAME_CACHE[sport][date]
 
 def getRecapVCO(date, type, recap, sport):
 	def getRecapItems(videos):
@@ -309,12 +306,16 @@ def Feeds(date, game_id, sport):
 			break
 
 	oc = ObjectContainer(title2="Feeds for %s" % g.title, no_cache=True)
+	if sport =="nhl":
+		thumb = R(THUMB_NHL)
+	else:
+		thumb = R(THUMB_MLB)
 
 	for f in filter(lambda f: f.viewable, game.feeds):
 		try:
 			oc.add(getStreamVCO(date, game, f))
 		except:
-			oc.add(DirectoryObject(title = "Game feed expired.", summary = "Full game feed expired.", thumb=R(THUMB_NHL)))
+			oc.add(DirectoryObject(title = "Game feed expired.", summary = "Full game feed expired.", thumb=thumb))
 			break
 
 	for r in game.recaps:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,4 +1,3 @@
-import logging
 import datetime
 import random
 import re

--- a/Contents/Code/game.py
+++ b/Contents/Code/game.py
@@ -173,7 +173,7 @@ class Game:
                     dt = datetime(1,1,1) + delta
                     return "Starts in %sh %sm %ss" % (dt.hour, dt.minute, dt.second)
             def mlb_remaining(state, time):
-                if "In Progress" in state:
+                if "Live" in state:
                     inning = g["linescore"]["currentInningOrdinal"]
                     half = g["linescore"]["inningHalf"]
                     return "%s %s" % (half, inning)
@@ -198,7 +198,7 @@ class Game:
             if sport == "nhl":
                 game.time_remaining = nhl_remaining(game.state, game.time)
             else:
-                game.time_remaining = mlb_remaining(game.state, game.time)
+                game.time_remaining = mlb_remaining(g["status"]["abstractGameState"], game.time)
             game.away_full_name = away["name"]
             game.home_full_name = home["name"]
             try:


### PR DESCRIPTION
Okay to start off, the first commit fixes #62. What was happening was that the plugin would get the NHL/MLB m3u8, but it would be expired and produce a 404 error. Now I implemented a check in `__init__.py` and if it catches an error then a "Game feed expired." item appears. Also the recap video was erroring out for iOS because plex was sending an extra argument which the browser would ignore, so I added a `**kwargs` expectation for that. The result is now this:
TODO: IMAGE of NHL and MLB Date that shows game expired
<img width="765" alt="image" src="https://user-images.githubusercontent.com/6157937/54076482-1e1a6380-427a-11e9-9239-526d69ddea31.png">

Second another bug fix, I noticed that if you went to an MLB day, then an NHL day the `GAME_CACHE` would remember the MLB games and include them in the description for the NHL day. It was the same for the reversed. I hope that makes sense. The fix was to change the `GAME_CACHE` list to a dictionary that had two keys `'mlb' and 'nhl'` and make the GAME_CACHE references store the dates and games based on sport. This partially relates to:

Third, I wanted to make the MLB days and games display just like the NHL so they don't look as abandoned. So the list of dates now displays like so:
<img width="1429" alt="image" src="https://user-images.githubusercontent.com/6157937/54076465-ef9c8880-4279-11e9-9492-4739f40e84c3.png">

And the actual dates displays like so:
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/6157937/54076474-03e08580-427a-11e9-9d35-720b63f55f4a.png">

I think this really ups the quality. If this is too much for you, I can roll back the changes to just fix the 404, iOS, and cache errors.