### PR TITLE
Fixes new MLB API changes for recaps and extended highlights

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -132,6 +132,20 @@ def getRecapVCO(date, type, recap, sport):
 	def getRecapItems(videos):
 		objects = []
 		for video in videos:
+			if sport == "mlb":
+				objects.insert(0, MediaObject(
+					container = Container.MP4,
+					video_codec = VideoCodec.H264,
+					audio_codec = AudioCodec.AAC,
+					video_resolution = 720,
+					audio_channels = 2,
+					height = 720,
+					width = 1280,
+					parts = [
+						PartObject(key=Callback(PlayRecap, url=video["url"]))
+					]
+				))
+				break
 			bitrate = int(video["name"].split("_")[1][0:-1])
 			height = int(video["height"])
 			if Prefs['quality'][0:3] == str(height):

--- a/Contents/Code/game.py
+++ b/Contents/Code/game.py
@@ -87,7 +87,7 @@ class Recap(object):
             recap.year = int(item["date"][0:4])
             recap.studio = sport
             recap.tagline = item["blurb"]
-            recap.rid = item["id"]
+            recap.rid = item["mediaPlaybackId"]
             try:
                 min, sec = item["duration"].split(":")
                 hr = 0
@@ -107,14 +107,22 @@ class Recap(object):
                     widest = cut["width"]
             
             recap.image_url = pcut["src"]
-            recap.videos = [vid for vid in item["playbacks"] if vid["name"][0:5] == "FLASH"]
+            if sport == "MLB":
+                recap.videos = [vid for vid in item["playbacks"] if vid["name"] == "mp4Avc"]
+            else:
+                recap.videos = [vid for vid in item["playbacks"] if vid["name"][0:5] == "FLASH"]
             
             return recap
 
         if "media" in content:
-            return [fromItem(item)
-                    for stream in content["media"]["epg"] if stream["title"] == content_title
-                    for item in stream["items"]]
+            if sport == "MLB":
+                return [fromItem(item)
+                        for stream in content["media"]["epgAlternate"] if stream["title"] == content_title
+                        for item in stream["items"]]
+            else:
+                return [fromItem(item)
+                        for stream in content["media"]["epg"] if stream["title"] == content_title
+                        for item in stream["items"]]
         else:
             return []
 


### PR DESCRIPTION
Fixes #66 

Changes the way recap feeds are search for MLB games and loaded into the MediaObject container for Plex.