### PR TITLE
Fixes MLB description issue

### DIFF
--- a/Contents/Code/game.py
+++ b/Contents/Code/game.py
@@ -83,7 +83,10 @@ class Recap(object):
             	recap.title = item["title"]
             else:
             	recap.title = 'Recap'
-            recap.summary = item["description"]
+            try:
+                recap.summary = item["description"]
+            except KeyError:
+                recap.summary = item["blurb"] #fixes MLB forgetting a description
             recap.year = int(item["date"][0:4])
             recap.studio = sport
             recap.tagline = item["blurb"]


### PR DESCRIPTION
Fixes #68.

The blurb and description are the same for the extended highlights, and they didn't forget that, so just set the recap summary to the blurb too. Hopefully they don't forget both in the future.